### PR TITLE
Fix bug in untokenized alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-05
+
+### Fixed
+- Incorrect segmentation for plain (non-tokenized) input: the word-internal
+  "don't start a segment with an internal piece" penalty in
+  `additionalInsertionCosts` was applied unconditionally. Because `isInternal()`
+  treats every whitespace word as internal (no leading `▁` marker), the 1000-cost
+  penalty fired on every segment-initial insertion, forcing trailing tokens into
+  the wrong segment and yielding suboptimal alignments. The penalty is now gated
+  by the `segmenting` flag (consistent with the sibling `extra_cost` term), so it
+  only applies in SentencePiece/tokenized mode. Added a `whitespace_segment`
+  regression test covering this case.
+- `mweralign` CLI now requires `--ref-file/-r` and `--hyp-file/-t`, printing a
+  usage error instead of crashing with `AttributeError: 'NoneType' object has no
+  attribute 'readlines'` when run with no arguments.
+
 ## [1.1.0] - 2026-06-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ test-command = "pytest {project}/python/tests"
 
 [project]
 name = "mweralign"
-version = "1.1.0"
+version = "1.1.1"
 description = "Minimum Word Error Rate Alignment for speech recognition evaluation"
 authors = [{name = "Matt Post", email = "mattpost@microsoft.com"}]
 readme = "README.md"

--- a/python/mweralign/__init__.py
+++ b/python/mweralign/__init__.py
@@ -18,5 +18,5 @@ limitations under the License.
 
 from .mweralign import MwerAlign, align_texts
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __all__ = ["MwerAlign", "align_texts"]

--- a/python/mweralign/mweralign.py
+++ b/python/mweralign/mweralign.py
@@ -119,8 +119,8 @@ def main():
     import sys
     
     parser = argparse.ArgumentParser(description='Minimum Word Error Rate Alignment')
-    parser.add_argument('--ref-file', "-r", type=argparse.FileType("r"), help='Reference text or file')
-    parser.add_argument('--hyp-file', "-t", type=argparse.FileType("r"), help='Hypothesis text or file')
+    parser.add_argument('--ref-file', "-r", type=argparse.FileType("r"), required=True, help='Reference text or file')
+    parser.add_argument('--hyp-file', "-t", type=argparse.FileType("r"), required=True, help='Hypothesis text or file')
     parser.add_argument("--docid-file", "-d", type=argparse.FileType("r"), default=None, help="Docid file")
     parser.add_argument('--output', '-o', type=argparse.FileType("w"), default=sys.stdout,
                         help='Output file (default: stdout)')

--- a/python/tests/regression/whitespace_segment/cmd
+++ b/python/tests/regression/whitespace_segment/cmd
@@ -1,0 +1,1 @@
+-r ref.txt -t hyp.txt

--- a/python/tests/regression/whitespace_segment/expected.txt
+++ b/python/tests/regression/whitespace_segment/expected.txt
@@ -1,0 +1,4 @@
+hello 
+this is a meeting 
+welcome here everybody 
+good-bye see you 

--- a/python/tests/regression/whitespace_segment/hyp.txt
+++ b/python/tests/regression/whitespace_segment/hyp.txt
@@ -1,0 +1,3 @@
+hello this is a
+meeting welcome here everybody
+good-bye see you

--- a/python/tests/regression/whitespace_segment/ref.txt
+++ b/python/tests/regression/whitespace_segment/ref.txt
@@ -1,0 +1,4 @@
+hello
+this is a meeting
+welcome everybody
+good-bye

--- a/src/mwerAlign.cc
+++ b/src/mwerAlign.cc
@@ -252,8 +252,13 @@ bool MwerSegmenter::isInternal(const unsigned int w) const
 unsigned int MwerSegmenter::additionalInsertionCosts(const unsigned int ref_next, const unsigned int ref_prev, bool is_new_sent,
                                                      const unsigned int w) const
 {
-    // large cost if we're putting an internal word at the start of a sentence
-    if (is_new_sent && isInternal(w)) {
+    // large cost if we're putting an internal word at the start of a sentence.
+    // This only makes sense when the input is tokenized (e.g. with SentencePiece),
+    // where word-internal pieces lack the leading marker. With plain whitespace
+    // input every word looks "internal" (isInternal() == true), so without the
+    // segmenting guard this penalty would fire on every segment-initial insertion
+    // and corrupt the alignment.
+    if (segmenting && is_new_sent && isInternal(w)) {
         return 1000;
     }
 


### PR DESCRIPTION
Was penalizing leading words even when not tokenizing.

Closes #4.